### PR TITLE
Restricting Application deployment for iOS 

### DIFF
--- a/blueprint/abac/hybrid-intune-applications-ios.md
+++ b/blueprint/abac/hybrid-intune-applications-ios.md
@@ -4,9 +4,58 @@ title: Hybrid - Microsoft Endpoint Manager - Intune applications for iOS devices
 menu: abac
 ---
 
+## Apple Business Manager Applications
+
+### Apple Business Manager VPP licenses
+
+For each of the following apps complete the license purchase in the Apple Business Manager Portal:
+* Applications: 
+  * Microsoft Company Portal
+  * Adobe Acrobat Reader
+  * Microsoft PowerApps
+  * Microsoft Edge
+  * Microsoft Excel
+  * Microsoft Outlook
+  * Microsoft PowerPoint
+  * Microsoft Word
+  * Microsoft Office
+  * Microsoft OneNote
+  * Microsoft Planner
+  * Microsoft Power BI
+  * Azure Information Protection
+  * Microsoft SharePoint
+  * Microsoft StaffHub
+  * Microsoft OneDrive
+  * Microsoft Teams
+  * Microsoft Stream
+  * Microsoft Visio Viewer
+  * Microsoft Whiteboard
+* Assign to: `Intune MDM`
+* Quantity: `Number of Agency Devices`
+
+
+### Apple Business Manager location token
+
+`Apple Business Manager > Settings > Apps and Books`
+
+* Location Token: `Download Location Token`
+
+`Microsoft Endpoint Manager > Tenant Administration > Connectors and tokens > Apple VPP tokens`
+
+* Token Name: `<Agency Acronym> VPP token`
+* Apple ID: `<Agency ID>@<Agency>.gov.au`
+* VPP token file: `Downloaded from Apple Business Manager above`
+* Settings:
+  * Take control of token from another MDM: `Yes`
+  * Country/Region: `Australia`
+  * Type of VPP account: `Business`
+  * Automatic updates: `Yes`
+  * I grant Microsoft permission to send both user and device information to Apple: `I agree`
+* Scope tags: `Default`
+
 ## Intune applications
 
-The following Microsoft Endpont Manager - Intune (Intune) applications can be found in the Azure Portal at `Microsoft Endpoint Manager > Apps > All apps`
+The following Microsoft Endpoint Manager - Intune (Intune) applications can be found in the Azure Portal at `Microsoft Endpoint Manager > Apps > All apps`
 
 ### Adobe Acrobat Reader for PDF
 
@@ -32,6 +81,7 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Available for enrolled devices: `rol-Agency-Administrators`, `rol-Agency-Users`
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Authenticator
 
@@ -57,6 +107,7 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Edge
 
@@ -78,10 +129,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Edge](/assets/images/abac/microsoft-edge.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Excel
 
@@ -103,10 +155,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Excel](/assets/images/abac/microsoft-excel.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft OneDrive
 
@@ -128,10 +181,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft OneDrive](/assets/images/abac/microsoft-onedrive.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft OneNote
 
@@ -154,9 +208,10 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
 * Scope tags: `Default`
 * Assignments
   * Required: -
-  * Available for enrolled devices: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Available for enrolled devices: `grp-iOS-Dynamic`
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Outlook
 
@@ -178,10 +233,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Outlook](/assets/images/abac/microsoft-outlook.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft PowerPoint
 
@@ -204,9 +260,10 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
 * Scope tags: `Default`
 * Assignments
   * Required: -
-  * Available for enrolled devices: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Available for enrolled devices: `grp-iOS-Dynamic`
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft SharePoint
 
@@ -229,9 +286,10 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
 * Scope tags: `Default`
 * Assignments
   * Required: -
-  * Available for enrolled devices: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Available for enrolled devices: `grp-iOS-Dynamic`
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Teams
 
@@ -253,10 +311,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Teams](/assets/images/abac/microsoft-teams.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Word
 
@@ -278,10 +337,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Word](/assets/images/abac/microsoft-word.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Power Apps
 
@@ -303,10 +363,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![PowerApps](/assets/images/abac/microsoft-power-apps.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ### Microsoft Whiteboard
 
@@ -328,10 +389,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Whiteboard](/assets/images/abac/Whiteboard.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
   ### Microsoft Planner
 
@@ -353,10 +415,11 @@ The following Microsoft Endpont Manager - Intune (Intune) applications can be fo
   * Logo: ![Microsoft Planner](/assets/images/abac/Planner.png)
 * Scope tags: `Default`
 * Assignments
-  * Required: `rol-Agency-Administrators`, `rol-Agency-Users`
+  * Required: `grp-iOS-Dynamic`
   * Available for enrolled devices: -
   * Available with or without enrollment: -
   * Uninstall: -
+  * License Type: `Device licensing`
 
 ## iOS app protection policy
 

--- a/blueprint/abac/hybrid-intune-configuration-ios.md
+++ b/blueprint/abac/hybrid-intune-configuration-ios.md
@@ -75,7 +75,7 @@ The following can be found at `Microsoft Endpoint Manager > Devices > Configurat
     * Block download of explicit sexual content in Apple Books: `Yes`
     * Allow managed apps to write contacts to unmanaged contacts accounts: `Not configured`
     * Rating Region: `No region configured`
-    * Block App store: `Not configured`
+    * Block App store: `Yes`
     * Block installing apps using App Store: `Not configured`
     * Block automatic app downloads: `Not configured`
     * Block playback of explicit iTunes music, podcast, or news content: `Yes`

--- a/blueprint/abac/hybrid-intune-enrolment-ios.md
+++ b/blueprint/abac/hybrid-intune-enrolment-ios.md
@@ -4,25 +4,37 @@ title: Hybrid - Microsoft Endpoint Manager - Intune enrolment for iOS devices
 menu: abac
 ---
 
-## Apple Device Enrolment Program
+## Apple Automated Device Enrollment
 
-`Intune > Devices > Enroll devices > Apple enrollment > Enrollment program tokens`
+`Microsoft Endpoint Manager > Devices > Enroll devices > Apple enrollment > Enrollment program tokens`
 
-* Name: `<Agency Acronym> iOS DEP enrolment`
+* Name: `<Agency Acronym> iOS ADE enrolment`
 * Description: -
 * Platform: `iOS`
 * Token
-  * Token name: `Intune Dev`
-  * Program type: `Device Enrollment Program`
+  * Token name: `Intune ADE`
+  * Program type: `Apple Business Manager`
   * Apple ID: `<Agency ID>@<Agency>.gov.au`
-  * Default iOS Enrollment Profile: `<Agency Acronym> iOS DEP enrolment`
-* Management Settings
+  * Token: `Generated in Apple Business Manager Portal below`
+
+`Apple Business Manager Portal > Settings > Device Management Settings`
+
+* Server Name: `Intune MDM`
+* Authorisation information: `PEM file from Microsoft Endpoint Manager`
+
+## Apple Enrollment Profile
+
+* Name `<Agency Acronym> iOS enrollment profile`
+* Description: -
+* User Affinity & Authentication Method
   * User affinity: `Enroll with User Affinity`
   * Select where users must authenticate: `Company Portal`
-  * Install Company Portal with VPP: `No VPP tokens found`
+  * Install Company Portal with VPP: `Use Token`
+  * Run Company Portal in Single App Mode until authentication: `No`
 * Management Options
-  * Locked enrollment: `Yes`
-  * Sync with computers: `Deny All`
+  * Supervised: `Yes`
+* Locked enrollment: `Yes`
+* Sync with computers: `Deny All`
 * Device Name
   * Apply device name template (supervised only): `Yes`
   * Device Name Template: `<Agency Acronym>-{SERIAL}-{DEVICETYPE}`
@@ -40,20 +52,26 @@ menu: abac
   * Zoom: `Show`
   * Siri: `Hide`
   * Diagnostic Data: `Hide`
+  * Restore Completed: `Hide`
+  * Software Update Completed: `Hide`
   * Display Tone: `Show`
   * Privacy: `Hide`
   * Android Migration: `Hide`
-  * Home Button: `Show`
-  * iMessage & FaceTime: `Show`
-  * Onboarding: `Hide`
-  * Screen Time: `Hide`
-  * SIM Setup: `Show`
-  * Software Update: `Show`
+  * Onboarding:
   * Watch Migration: `Hide`
+  * Screen Time: `Hide`
+  * Software Update: `Show`
+  * SIM Setup: `Show`
   * Appearance: `Show`
-  * Express Language: `Show`
-  * Preferred Language Order: `Show`
   * Device to Device Migration: `Hide`
+  * Registration: `Show`
+  * FileVault: `Hide`
+  * iCloud diagnostics: `Hide`
+  * iCloud Storage: `Hide`
+
+### Default Profile
+
+* Set Default Profile:`<Agency Acronym> iOS enrollment profile`
 
 ## Enrolment types (preview)
 

--- a/blueprint/client-devices.md
+++ b/blueprint/client-devices.md
@@ -1210,6 +1210,10 @@ MDM provides the capability to configure iOS devices. These devices must be conf
 * Branding – The Agencies branding for lock screen, wallpapers, and reporting if the device is lost can be configured.
 * Device features – Configures device features, for example, AirDrop and Bluetooth pairing, within iOS devices.
 
+Microsoft also provide a [Microsoft Supervised patterns](https://docs.microsoft.com/en-us/mem/intune/enrollment/ios-ipados-supervised-device-security-configurations) which is designed to assist in the securing iOS devices based on organisation risk requirements. 
+
+Intune and Apple Business Manager in combination can be leveraged to restrict the applications deployed to iOS devices. When restricting application deployments, the App Store is blocked and all application management is completed through the Company Portal. In this pattern, all applications must be licensed within Apple Business Manager and use device based licensing. 
+
 Securing iOS devices Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
@@ -1232,6 +1236,7 @@ Virtual Private Network (VPN)  | Configured | Per-app VPN will be set up to secu
 **Branding** | | |
 Lock Screen and background branding | Configured | Agency branding will be applied to endpoints. It is recommended that agencies include the contact information of the relevant IT Support in the event that a device is lost.
 **Device Features** | | |
+App Store | Blocked | To meet ACSC Essential 8 application control guidance and to align to the [Microsoft Supervised High Security pattern](https://docs.microsoft.com/en-us/mem/intune/enrollment/ios-ipados-supervised-device-security-configurations#supervised-high-security-level-3)
 Disable Screenshot and screen recording | Disable | Disablement of screenshot and screen recording, disable users from taking a snapshot of protected documents
 Allow iCloud backup, document data and Keychain | Disable | The Agencies data on mobile devices must be uploaded into the Agencies tenant. This is done to prevent accidental information being backed up to iCloud or another unsecure data store
 Managed Open-In | Enable  | Managed Open-In is enable segregates between corporate managed and personal application in an iOS device. This in line with the ACSC iOS Secure Configuration Hardening guide for PROTECTED devices.
@@ -1254,7 +1259,7 @@ Securing iOS Design Decisions for all agencies and implementation types.
 Decision Point | Design Decision | Justification
 --- | --- | ---
 Managed Applications | Microsoft Corporate Portal<br>Microsoft Azure Information Protection<br>Microsoft Word<br>Microsoft Excel<br>Microsoft Outlook<br>Microsoft PowerPoint<br>Microsoft Teams<br>Microsoft Edge<br>Adobe Reader<br>Microsoft OneDrive<br>Microsoft OneNote<br>Microsoft Whiteboard<br>Microsoft Planner<br>PowerApps | This is to meet the Agencies requirement for managed applications
-Application VPN configuration | Configured for Managed Applications | Managed applications will use VPN to secure its connection to the Agencies Office 365 tenant
+Application VPN configuration | Configured for Managed Applications | Managed applications will use VPN to secure its connection to the Agencies Microsoft 365 tenant
 Disable organisation data to be backed up to iCloud | Disable | PROTECTED must be stored within the Agencies environment / corporate data store
 Encrypt organisation data in mobile device | Configured | To ensure encryption requirements are met based on ACSC hardening requirements. 
 Send organisation data to unmanaged apps | Policy managed apps with Open In/Share Filtering | Prevents data to be shared between managed application stated above and other unmanaged application on the device


### PR DESCRIPTION
Bringing the blueprint in line with Microsoft iOS secure framework.

Changes:
1. Blocked the App Store
2. Changed iOS app assignments to device assignments
3. Added sections on configuring Apple Business Manager and location tokens
4. Updated the enrolment process