### PR TITLE
Update to Client Devices Design - Fast User Switching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   jekyll-last-modified-at
 
 BUNDLED WITH
-   2.2.19
+   2.2.23

--- a/blueprint/client-devices.md
+++ b/blueprint/client-devices.md
@@ -465,7 +465,7 @@ Fast User Switching Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-Fast User Switching | Disabled | Meets ACSC Windows 10 1909 hardening guidelines
+Fast User Switching | Disabled | To minimise potential attack surface of the SOE.
 
 ### Corporate branding
 


### PR DESCRIPTION
Update to rationale to remove reference to ACSC hardening guide as the 1909 version does not include guidance on fast user switching.