### PR TITLE
Addition of Viva Learning to Blueprint

### DIFF
--- a/blueprint/abac/office-365.md
+++ b/blueprint/abac/office-365.md
@@ -127,6 +127,7 @@ The following table describes the Microsoft 365 Services settings for all implem
 | Sway                                      | Disabled                                                     |
 | User consent to apps                      | Disabled                                                     |
 | User owned apps and services              | Disabled                                                     |
+| Viva Learning                             | Diagnostic data: Unchecked<br>LinkedIn Learning: Unchecked<br>Microsoft Learn: Unchecked<br>Microsoft 365 Training: Unchecked<br>SharePoint: Unchecked |
 | Whiteboard                                | Turn on Whiteboard for everyone in your org: Checked<br>Level of diagnostic data to send to Microsoft: Neither<br>Allow the use of optional connected experiences in Whiteboard: Unchecked<br>Enable easy sharing of Whiteboard from Surface Hub: Unchecked<br>Enable storing new whiteboards in OneDrive: Unchecked |
 
 ### Security and privacy

--- a/blueprint/office-365.md
+++ b/blueprint/office-365.md
@@ -1715,7 +1715,9 @@ Decision Point | Design Decision | Justification
 Publishing through iCalendar feed | Disabled | To prevent users from sharing sensitive information via iCalendar feeds.
 
 ## Viva Learning
-Viva Learning is a Microsoft Teams app which aims to assist users to find and access training from multiple content providers. Viva Learning content can be enabled from LinkedIn Learning, Microsoft Learn, and Microsoft 365 Training. Administrators can also configure a SharePoint site to host addition content.
+Viva Learning is a Microsoft Teams app which aims to assist users to find and access training from multiple content providers. Viva Learning content can be enabled from LinkedIn Learning, Microsoft Learn, and Microsoft 365 Training. Administrators can also configure a SharePoint site to host addition content, which can be done without enabling content from other providers.
+
+Note, Viva Learning content is subject to terms other than the Microsoft Product Terms, including third-party content provider’s terms, which have not been reviewed as part of the Office 365 IRAP assessment. It is recommended that Agencies review these terms as part of any risk assessment relating to the use of this content.
 
 Viva Learning Design Decisions for all agencies and implementation types.
 

--- a/blueprint/office-365.md
+++ b/blueprint/office-365.md
@@ -1670,7 +1670,7 @@ The Whiteboard tool also offers optional connected experiences. These experience
 
 The Whiteboard tool can be used with the Microsoft Surface hub appliance. When using the tool easy sharing can be configured. Easy sharing allows sharing of Whiteboard sessions without logging into the Surface Hub appliance. 
 
-Microsoft Whiteboard Configuration applicable to all agencies and implementation types.
+Microsoft Whiteboard Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
@@ -1693,7 +1693,7 @@ Surveys and forms can be leveraged for potentially malicious purposes. Phishing 
 
 At time of writing, Microsoft Forms processes and stores data for Australian tenants within the [United States](https://docs.microsoft.com/en-us/microsoft-365/enterprise/o365-data-locations?view=o365-worldwide), it is recommended to not process sensitive information using Microsoft Forms.
 
-Microsoft Forms Configuration applicable to all agencies and implementation types.
+Microsoft Forms Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
@@ -1708,8 +1708,21 @@ Phishing protection | Enabled | Blocks forms from being shared or distributed if
 ## Microsoft Planner
 Microsoft Planner is a task planning and assignment tool which can integrate with other Microsoft 365 services such as Microsoft Teams. Planner leverages iCalendar publishing to allow planner users to add tasks into their calendar. When tasks are published via iCalendar, they are available to all users with the iCalendar URL. The users can be both internal and external to the organisation.
 
-Microsoft Planner Configuration applicable to all agencies and implementation types.
+Microsoft Planner Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
 Publishing through iCalendar feed | Disabled | To prevent users from sharing sensitive information via iCalendar feeds.
+
+## Viva Learning
+Viva Learning is a Microsoft Teams app which aims to assist users to find and access training from multiple content providers. Viva Learning content can be enabled from LinkedIn Learning, Microsoft Learn, and Microsoft 365 Training. Administrators can also configure a SharePoint site to host addition content.
+
+Viva Learning Design Decisions for all agencies and implementation types.
+
+Decision Point | Design Decision | Justification
+--- | --- | ---
+Diagnostic data | Disabled | Prevent data from being provided to Microsoft for diagnostic and product improvements.
+LinkedIn Learning | Disabled | LinkedIn Learning content is subject to third-party content provider’s terms that have not been reviewed as part of the Office 365 IRAP assessment.
+Microsoft Learn | Disabled | Microsoft Learn content is subject to terms other than the Microsoft Product Terms and have not been reviewed as part of the Office 365 IRAP assessment.
+Microsoft 365 Training | Disabled | Microsoft 365 Training content is subject to terms other than the Microsoft Product Terms and have not been reviewed as part of the Office 365 IRAP assessment.
+SharePoint | Disabled | The blueprint does not provide training content. Agencies with existing content may enable a SharePoint site to host Viva Learning content, subject to internal assessment.


### PR DESCRIPTION
Added design decisions and configuration for **Viva Learning** to the Office 365 design and ABAC respectively.

Also, minor corrections to the design decision table lead-in sentences for Whiteboard, Forms and Planner.