### PR TITLE
Updates based on Microsoft feedback

### DIFF
--- a/blueprint/abac/office-365.md
+++ b/blueprint/abac/office-365.md
@@ -103,7 +103,7 @@ The following table describes the Microsoft 365 Services settings for all implem
 
 | Item                                      | Configuration                                                |
 | ----------------------------------------- | ------------------------------------------------------------ |
-| Azure Speech Services                     | Disabled                                                     |
+| Azure Speech Services                     | Enabled                                                      |
 | Bookings                                  | Disabled                                                     |
 | ‎Briefing‎ email from ‎Microsoft Viva‎        | Enabled                                                      |
 | Calendar                                  | Disabled                                                     |
@@ -120,7 +120,7 @@ The following table describes the Microsoft 365 Services settings for all implem
 | Modern Authentication                     | Turn on modern authentication for Outlook 2013 for Windows and later (recommended): Checked<br>Allow access to basic authentication protocols: Unchecked (All)                                 |
 | News                                      | Disabled                                                     |
 | ‎Office‎ installation options               | Once a month (Monthly Enterprise Channel)<br>Apps for Windows and mobile devices: Office (includes Skype for Business)<br>Apps for Mac: Office                                               |
-| Office on the web                         | Disabled                                                     |
+| Office on the web (third-party storage services) | Disabled                                                     |
 | Office Scripts                            | Disabled                                                     |
 | Reports                                   | Disabled                                                     |
 | SharePoint                                | Users can share with: New and existing guests - guests must sign in or provide a verification code |
@@ -1016,6 +1016,7 @@ Note, policies that are not configurable are not included below.
 | Whiteboard                                      | On                                                           |
 | Shared notes                                    | On                                                           |
 | Select video filters                            | All filters                                                  |
+| Let anonymous people join a meeting             | Off                                                          |
 | Let anonymous people start a meeting            | Off                                                          |
 | Roles that have presenter rights in meetings    | Everyone, but user can override                              |
 | Automatically admit people                      | People in my organization                                    |

--- a/blueprint/abac/office-365.md
+++ b/blueprint/abac/office-365.md
@@ -938,6 +938,20 @@ The following table describes the Teams policy configuration settings for all im
 | Description             | Not configured            |
 | Create private channels | True                      |
 
+### Teams apps
+
+`Microsoft Teams admin center > Teams apps > Permission policies`
+
+The following table describes the Teams apps configuration settings for all implementation types.
+
+| Item                    | Configuration             |
+| ----------------------- | ------------------------- |
+| Name                    | Global (Org-wide default) |
+| Description             | Not configured            |
+| Microsoft apps          | Allow all apps            |
+| Third-party apps        | Block all apps            |
+| Custom apps             | Block all apps            |
+
 ### Calling policy
 
 `Microsoft Teams admin center > Voice > Calling policies`

--- a/blueprint/client-devices.md
+++ b/blueprint/client-devices.md
@@ -321,7 +321,7 @@ Universal Windows Platform Application configuration applicable to all agencies 
 
 Configuration | Value | Description
 --- | --- | ---
-Alarms and Clock | Removed | A versatile combination of alarm clock app, world clock, timer, and stopwatch.
+Alarms and Clock | Provisioned | A versatile combination of alarm clock app, world clock, timer, and stopwatch.
 Bing | Removed | Weather and News. 
 Calculator | Provisioned | A calculator that includes standard, scientific, and programmer modes, as well as a unit converter.
 Camera | Removed | The redesigned Camera is faster and simpler than ever before.
@@ -1192,6 +1192,7 @@ Windows 10 Hardening Design Decisions for all agencies and implementation types.
   * Restrict Unauthenticated RPC clients: Enabled (RPC Runtime Unauthenticated Client Restriction to Apply: Authenticated)
 * Reporting system information
   * Justification: To align with the ACSC Windows 10 hardening guidance.
+  Note, additional telemetry is required for [Desktop Analytics](/blueprint/client-devices.html#telemetry-collection) and Agencies may choose to enable it to aid in Microsoft Support troubleshooting.
   * Microsoft Support Diagnostic Tool:
     * Turn on MSDT interactive communication with support provider: Disabled
   * Turn off Inventory Collector: Enabled
@@ -1382,8 +1383,8 @@ Decision Point | Design Decision | Justification
 Guest Account (Local) | Disabled | To align with the ACSC Windows 10 hardening guidance. 
 Guest Account Name | Renamed | To align with the ACSC Windows 10 hardening guidance.
 Microsoft Accounts | Disabled | To align with the ACSC Windows 10 hardening guidance.
-Windows Hello for Business | Disabled | Does not meet security requirements.
-Windows Hello for Business Configuration Method | Disabled | Does not meet security requirements.
+Windows Hello for Business | Agency decision | As per the ACSC Windows 10 hardening guidance, Agencies may consider if Windows Hello for Business is suitable for their environment.
+Windows Hello for Business Configuration Method | Agency decision | As per the ACSC Windows 10 hardening guidance, Agencies may consider if Windows Hello for Business is suitable for their environment.
 
 Additional Identity Providers Design Decisions for cloud native implementations
 

--- a/blueprint/office-365.md
+++ b/blueprint/office-365.md
@@ -125,7 +125,7 @@ Services and Add-ins Design Decisions for all agencies and implementation types.
 
 Decision Point        | Design Decision | Justification
 ---                   | ---             | ---
-Azure Speech Services | Disabled        | Enabling the organization-wide language model allows Azure speech service to gather data from emails and other locations to improve M365 applications that use Azure Speech Services. There is no requirement for text to speech in the blueprint and should be evaluated further if there is an agency requirement. 
+Azure Speech Services | Enabled        | Enabling the organization-wide language model allows Azure Speech service to gather data from emails and other locations to improve M365 applications that use Azure Speech services. The Azure Speech service has been IRAP assessed as part of Azure and enables greater accessibility features as part of the Blueprint. 
 Bookings              | Disabled        | Exposes a public web page that provides access to user calendars for 3rd parties. There is no requirement to enable the feature as other methods of collaboration are in use. 
 ‎Briefing‎ email from ‎Microsoft Viva‎	| Enabled | Enabled by default to improve productivitiy, individual users can unsubscribe if desired.
 Calendar              | Disabled        | External sharing is disabled to prevent potential data spills.
@@ -140,7 +140,7 @@ Microsoft 365 Group  | Enabled | External collaboration will be conducted in Mic
 Modern Authentication | Enabled | Modern authentication is a group of technologies that combines authentication, authorisation and conditional access policies to secure an Office 365 tenant. Enabling of Modern Authentication provides ability to use Multi Factor Authentication.
 News                 | Disabled        | To prevent the display of Office 365 content and external news articles together in Edge.
 ‎Office‎ installation options | Enabled  | To manage the update and deployment of Office updates and components.
-Office on the web    | Disabled        | Do not allow users to open files in third party storage services in Office on the web as this may introduce risk of information disclosure or malicious content. 
+Office on the web    | Third-party storage services: Disabled        | Do not allow users to open files in third-party storage services in Office on the web as this may introduce risk of information disclosure or malicious content. 
 Office Scripts       | Disabled        | To prevent the execution of unapproved code.
 Reports              | Disabled        | Disable data reporting to Microsoft on Office 365 usage.
 SharePoint           | Enabled         | New and Existing guests must sign in or provide a verification code when accessing SharePoint data.
@@ -924,7 +924,7 @@ Legacy Features Design Decisions for all agencies and implementation types.
 Decision Point | Design Decision | Justification
 --- | --- | ---
 InfoPath | Not configured | InfoPath is going to be deprecated and it is recommended that InfoPath forms to be redeveloped into PowerApps in Office 365. 
-Records Management | Not configured | Records Management administrative screen provides configuration settings to route files from a SharePoint Document Library to a centralised SharePoint Records Management site. This is to support the traditional Centralised records management system in SharePoint.
+Records Management | Not configured | Records Management administrative screen provides configuration settings to route files from a SharePoint Document Library to a centralised SharePoint Records Management site. This is to support the traditional Centralised records management system in SharePoint.<br>Note, this is a separate feature from [records management in Microsoft 365](https://docs.microsoft.com/en-au/microsoft-365/compliance/records-management).
 Secure Store Settings | Not Configured | Secure Store in SharePoint Online provides a key vault to store all sensitive information in SharePoint. This is primarily used by InfoPath to store sensitive keys and passwords. It is recommended to use Azure Key Vault to store sensitive information. 
 Business Connectivity Settings | Not configured | Business Connectivity Settings provides SharePoint on-premises ability to consume information from third party OData Information store.<br>It is recommended to use Power BI to consume third party data and publish it to SharePoint Online.
 Search | Not configured | Search provides legacy support on crawled properties, managed properties and custom configuration required. 

--- a/blueprint/office-365.md
+++ b/blueprint/office-365.md
@@ -1131,7 +1131,7 @@ Team Policy | Configured<br>Disable private channels | Team policy will be left 
 Meeting Policies | Configured<br>Global policy:<br>Automatically admit people – Everyone in your organisation<br>Cloud Recording – Enabled with automatic deletion | Meeting policy dictates how audio, videos and applications that are used in a team meeting.<br>Require external participants to be admitted to a meeting to prevent unauthorised entrance.<br>Enables meetings to be recorded while reducing storage consumption.
 Live events Policies | Configured<br>Who can join live events:<br>Everyone in Organisation | Live events is configured to prevent users outside of the organisation (guest and external users) cannot attend these meeting.
 Messaging Policy | Configured | Messaging policy dictates how messaging is used in Teams. These includes usage of Giphy, Memes and stickers in messages.
-Teams app | Configured<br>Global Policy:<br>Block specific app from Microsoft Apps<br>* Forms<br>* Yammer<br>Block all Third-Party Apps<br>Block all Tenant Apps | Microsoft Forms and Yammer are hosted in United States. This will cause data sovereignty issue for the Agency. <br>All Third-Party Apps are blocked. These Third-Party apps needs to be evaluated individually.<br>Tenant Apps are custom developed applications created by the Agency. This should be enabled if it is required. 
+Teams apps | Configured<br>Global Policy:<br>Allow all Microsoft apps<br>Block all third-party apps<br>Block all custom apps | All third-party apps are blocked by the blueprint by default. The use of third-party apps should be risk assessed by Agencies individually.<br>Custom apps are custom developed applications created by the Agency. These should be enabled as required. 
 
 ### Unified communication
 
@@ -1698,7 +1698,7 @@ Microsoft Forms is capable of capturing the names of the organisational users wh
 
 Surveys and forms can be leveraged for potentially malicious purposes. Phishing protection for Microsoft Forms scans forms for common phishing questions. If they are detect, the form is prevented from being distributed or shared. Phishing protection only protects internal organisation forms.
 
-At time of writing, Microsoft Forms processes and stores data for Australian tenants within the [United States](https://docs.microsoft.com/en-us/microsoft-365/enterprise/o365-data-locations?view=o365-worldwide), it is recommended to not process sensitive information using Microsoft Forms.
+At time of writing, Microsoft Forms processes and stores data for Australian tenants within the [United States](https://docs.microsoft.com/en-au/microsoft-365/enterprise/o365-data-locations?view=o365-worldwide#australia), it is recommended to not process sensitive information using Microsoft Forms.
 
 Microsoft Forms Design Decisions for all agencies and implementation types.
 

--- a/blueprint/platform.md
+++ b/blueprint/platform.md
@@ -1592,9 +1592,9 @@ Retention policies are created that ensure that data is retained forever for:
 * Teams channel messages
 * Teams chats.
 
-Workstation configuration is stored in Intune. (AutoPilot rebuild).
+Workstation configuration is stored in Intune (Autopilot rebuild).
 
-Cloud based native Office 365 tools will not meet an agency's requirement for on-premises and cloud backups. Agencies will need to investigate third party backup solutions which can backup data either to a designated physical location or cloud backup/storage service.
+Agencies should review the native Microsoft 365 capabilities and determine if they meet their data preservation requirements, or if a third-party backup solution is required.
 
 RPO, RTO and Retention Periods Design Decisions for all agencies and implementation types.
 
@@ -1627,22 +1627,17 @@ Retention Policies | At discretion of Agency | Retention policies for the backup
 
 ### Data availability
 
-Microsoft Azure services are available globally and provides geographical, regional, data centre, virtual infrastructure, and application resiliency. This allows the Microsoft Azure platform and Office 365 to combat and minimise potential disasters such as customers loss of connectivity to data or loss of data.
+Microsoft Azure services are available globally and provides geographical, regional, data centre, virtual infrastructure, and application resiliency. This allows the Microsoft Azure platform and Microsoft 365 to combat and minimise potential disasters such as customers loss of connectivity to data or loss of data.
 
-Data availability is an important part of making sure that end users have access to the data when they require it. The cloud-based service of Microsoft Office 365 will replicate and store Agency's data in multiple data centres which are geographically dispersed  (see [Exchange data resiliency](https://docs.microsoft.com/en-us/office365/enterprise/office-365-exchange-data-resiliency) and [Office 365 data resiliency](https://docs.microsoft.com/en-us/office365/Enterprise/office-365-data-resiliency-overview)). The Office 365 applications that provide this data availability are:
+Data availability is an important part of making sure that end users have access to the data when they require it. The cloud-based service of Microsoft 365 will replicate and store Agency's data in multiple data centres which are geographically dispersed  (see [Exchange Online data resiliency in Microsoft 365](https://docs.microsoft.com/en-au/compliance/assurance/assurance-exchange-data-resiliency) and [Data resiliency in Microsoft 365](https://docs.microsoft.com/en-au/compliance/assurance/assurance-data-resiliency-overview)). 
 
-* Exchange
-* SharePoint
-* OneDrive
-* Teams.
-
-The data availability and resiliency of Office 365 cloud service is in-built and managed by Microsoft.
+The data availability and resiliency of Microsoft 365 cloud service is in-built and managed by Microsoft.
 
 Data Availability Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-Data Availability | Configured | Microsoft have in-built data availability into the Office 365 cloud services.
+Data Availability | Configured | Microsoft have in-built data availability into the Microsoft 365 cloud services.
 
 ## System administration
 


### PR DESCRIPTION
The following updates have been made to the Blueprint based on feedback received by the DTA from Microsoft Australia.

- Removed reference to data sovereignty and updated Microsoft Teams app design decision (Office 365 design and ABAC)
- Enabled Azure speech services and specified Office on the web is disabled for third-party storage services (Office 365 design and ABAC)
- Added clarification around Records Management (Office 365 design)
- Updated guidance around the use of Telemetry for Windows 10 (Client Devices design)
- Added Alarms and Clocks into the list of provisions apps for Windows 10 (Client Devices design)
- Updated Windows Hello for Business design decision to 'Agency decision' (Client Devices design)
- Updated wording around the use of cloud-native backup vs third-party backup solutions (Platform design)
- Removed list of services from Data availability section (Platform design)