### PR TITLE
generalise individual licence requirements

### DIFF
--- a/blueprint/client-devices.md
+++ b/blueprint/client-devices.md
@@ -255,11 +255,11 @@ Office 365 products require licensing to enable full functionality and support. 
 
 * Office 365 based activation - Office 365 is Microsoft's productivity solution in the cloud. Office 365 has two sets of suites: one for the small and medium business segment and one for the enterprise segment. These suites are sold across different channels and programs designed to meet each segment's needs. Products are assigned to users and then activated through the online Microsoft Office 365 licensing service.
 
-Activation and Licensing Design Decisions for all agencies and implementation types.
+Activation and Licencing Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-Licensing for Microsoft Windows 10 Enterprise <br>Microsoft Office 365 E5 | Microsoft 365 E5 which includes Windows 10 E5, Office 365 E5 and EM+S E5 per user | For agencies to meet their obligations under the ISM, PSPF, and ACSC cloud guidance as they relate to PROTECTED security classification. It is recommended in this design that agencies purchase a Microsoft 365 E5 licence for each user. 
+Licencing for Microsoft Windows 10 Enterprise <br>Microsoft Office 365 E5 | Microsoft 365 E5 which includes Windows 10 E5, Office 365 E5 and EM+S E5 per user | For agencies to meet their obligations under the ISM, PSPF, and ACSC cloud guidance as they relate to PROTECTED security classification. It is recommended in this design that agencies purchase a Microsoft 365 E5 licence for each user. 
 Windows Activation Method | Windows 10 Subscription | All devices will meet the requirements for Subscription Activation (a supported [Windows 10 version](https://docs.microsoft.com/en-us/windows/release-health/release-information) and internet access), as this is the simplest solution to implement and manage as part of the licensing entitlement. 
 Office Activation Method | Office 365 Subscription | All devices meet the requirement for Office 365 activation (internet access) as this is the simplest solution to implement and manage as part of the licensing entitlement. 
 
@@ -332,7 +332,7 @@ The Microsoft Public Store is the central location for browsing the library of a
 
 The Microsoft Store for Business (private store) allows organisations to purchase applications in larger volumes and customise which applications are available to users. Applications which are made available can either be distributed directly from the store or through a managed distribution approach. Applications which have been developed within the organisation can also be added and distributed as required.
 
-Licensing can also be managed through the Microsoft Store for Business and administrators can reclaim and reuse application licences.
+Licencing can also be managed through the Microsoft Store for Business and administrators can reclaim and reuse application licences.
 
 Microsoft Store Design Decisions for all agencies and implementation types.
 

--- a/blueprint/client-devices.md
+++ b/blueprint/client-devices.md
@@ -244,7 +244,7 @@ Windows 10 Build | 21H1 | At the time of the latest update to this design, build
 
 ### Activation and licencing
 
-License keys and activation processes are leveraged by Microsoft to ensure that the device or user is eligible to use the feature or run the product (i.e. Windows 10).
+Licence keys and activation processes are leveraged by Microsoft to ensure that the device or user is eligible to use the feature or run the product (i.e. Windows 10).
 
 Windows 10 licensing has evolved significantly since the initial release by Microsoft. In addition to the traditional activation methods for on premises networks (KMS, MAK and AD Based Activation) it is also possible to use Windows 10 Subscription Activation. The evolution of Windows 10 activation is described below:
 
@@ -255,33 +255,11 @@ Office 365 products require licensing to enable full functionality and support. 
 
 * Office 365 based activation - Office 365 is Microsoft's productivity solution in the cloud. Office 365 has two sets of suites: one for the small and medium business segment and one for the enterprise segment. These suites are sold across different channels and programs designed to meet each segment's needs. Products are assigned to users and then activated through the online Microsoft Office 365 licensing service.
 
-For agencies looking to alternate licensing arrangements, at a minimum, Microsoft recommends the following licensing in addition to the VSA 4 Common Cloud Commitment:
-
-* Microsoft 365 E5 Security.
-* Microsoft 365 E5 Compliance.
-
-The VSA 4 Common Cloud Commitment consists of:
-
-* Windows 10 E3.
-* Office 365 E3.
-* Enterprise Mobility and Security E3.
-* Productivity server licences (Exchange Server, SharePoint Server, Lync/Skype Server).
-* Office Device licences.
-
-These recommendations require a minimum subscription requirement of Microsoft 365 E3, Enterprise Mobility and Security E5 and Microsoft 365 E5 Compliance with one licence required for each user.
-
-This alternate configuration will not provide access to Azure Active Directory Premium P2 licencing meaning that the following components would need to be removed from the blueprint:
-
-* Azure Active Directory Identity Protection.
-* Azure Active Directory Privileged Identity Management (PIM).
-
-While this meets the Microsoft minimum guidance and will comply with the requirements of the ISM, the exclusion of these two features reduces the effectiveness of the security controls. Specifically, the Just-In-Time administrative access provided by PIM and the automated responses to detected suspicious activities will not be available.
-
-Activation and Licencing Design Decisions for all agencies and implementation types.
+Activation and Licensing Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-Licensing for Microsoft Windows 10 Enterprise <br>Microsoft Office 365 E5 | Microsoft 365 E5 which includes Windows 10 E5, Office 365 E5 and EM+S E5 per user | For agencies to meet their obligations under the ISM, PSPF, and ACSC cloud guidance as they relate to PROTECTED security classification. It is recommended in this design that agencies purchase a Microsoft 365 E5 licence for each user.
+Licensing for Microsoft Windows 10 Enterprise <br>Microsoft Office 365 E5 | Microsoft 365 E5 which includes Windows 10 E5, Office 365 E5 and EM+S E5 per user | For agencies to meet their obligations under the ISM, PSPF, and ACSC cloud guidance as they relate to PROTECTED security classification. It is recommended in this design that agencies purchase a Microsoft 365 E5 licence for each user. 
 Windows Activation Method | Windows 10 Subscription | All devices will meet the requirements for Subscription Activation (a supported [Windows 10 version](https://docs.microsoft.com/en-us/windows/release-health/release-information) and internet access), as this is the simplest solution to implement and manage as part of the licensing entitlement. 
 Office Activation Method | Office 365 Subscription | All devices meet the requirement for Office 365 activation (internet access) as this is the simplest solution to implement and manage as part of the licensing entitlement. 
 
@@ -354,7 +332,7 @@ The Microsoft Public Store is the central location for browsing the library of a
 
 The Microsoft Store for Business (private store) allows organisations to purchase applications in larger volumes and customise which applications are available to users. Applications which are made available can either be distributed directly from the store or through a managed distribution approach. Applications which have been developed within the organisation can also be added and distributed as required.
 
-Licensing can also be managed through the Microsoft Store for Business and administrators can reclaim and reuse application licenses.
+Licensing can also be managed through the Microsoft Store for Business and administrators can reclaim and reuse application licences.
 
 Microsoft Store Design Decisions for all agencies and implementation types.
 
@@ -786,7 +764,7 @@ Microsoft 365 Apps for enterprise provides there feature update channels for cus
 * Monthly Enterprise Channel: new office features are released in a predictable monthly schedule.
 * Semi-annual Enterprise Channel: new Office features are released twice a year. 
 
-Microsoft Project and Visio (365 and 2019) are available as click-to-run editions that can be either licensed through Microsoft 365 or through hybrid licensing. Regardless of the license type, they can be installed through Intune or MECM (for hybrid deployments). The installation media is configured using the [Office Deployment Tool (ODT)](https://www.microsoft.com/download/details.aspx?id=49117) which generates the installer and configuration options for the deployment. Microsoft Office 365 E3/E5 licensing does not include the rights to use these applications. There are some caveats to what combination of Office versions are supported alongside Project and Visio, please see the [supported scenarios](https://docs.microsoft.com/en-us/deployoffice/install-different-office-visio-and-project-versions-on-the-same-computer).
+Microsoft Project and Visio (365 and 2019) are available as click-to-run editions that can be either licenced through Microsoft 365 or through hybrid licensing. Regardless of the licence type, they can be installed through Intune or MECM (for hybrid deployments). The installation media is configured using the [Office Deployment Tool (ODT)](https://www.microsoft.com/download/details.aspx?id=49117) which generates the installer and configuration options for the deployment. Microsoft Office 365 E3/E5 licensing does not include the rights to use these applications. There are some caveats to what combination of Office versions are supported alongside Project and Visio, please see the [supported scenarios](https://docs.microsoft.com/en-us/deployoffice/install-different-office-visio-and-project-versions-on-the-same-computer).
 
 Microsoft Office Edition Design Decisions for all agencies and implementation types.
 
@@ -1729,7 +1707,7 @@ MDM provides the capability to configure iOS devices. These devices must be conf
 * Branding – The Agencies branding for lock screen, wallpapers, and reporting if the device is lost can be configured.
 * Device features – Configures device features, for example, AirDrop and Bluetooth pairing, within iOS devices.
 
-Using Intune together with Apple Business Manager provides the ability to restrict applications deployed to iOS devices. They improve the user experience during the onboarding process and remove the requirement for an Apple ID and the public Apple App Store. When restricting application deployments, the App Store is blocked and all application management is completed through the Intune Company Portal. All applications must be licensed within Apple Business Manager and use device based licensing. 
+Using Intune together with Apple Business Manager provides the ability to restrict applications deployed to iOS devices. They improve the user experience during the onboarding process and remove the requirement for an Apple ID and the public Apple App Store. When restricting application deployments, the App Store is blocked and all application management is completed through the Intune Company Portal. All applications must be licenced within Apple Business Manager and use device based licensing. 
 
 Securing iOS devices Design Decisions for all agencies and implementation types.
 
@@ -1737,7 +1715,7 @@ Decision Point | Design Decision | Justification
 --- | --- | ---
 Mobile Device Management | Mobile devices will be managed using Intune | Leveraging the capabilities already available in the licensing agreement. Intune and Apple Business Manager will be adopted to manage mobile devices.
 Security policies and hardening requirements | Security policies will be enforced on all mobile devices managed by the Agency | Security policies will be configured in line with the ACSC Security Configuration Guide – Apple iOS 14 Devices.
-Apple Business Manager Enrollment Token App Delivery | Agency licensed apps purchased under the Volume Purchase Program (VPP) are installed directly to devices, without needing an Apple ID on the device | Configured inline with ACSC iOS hardening guidance, simplifies management and improves user experience with device onboarding. 
+Apple Business Manager Enrollment Token App Delivery | Agency licenced apps purchased under the Volume Purchase Program (VPP) are installed directly to devices, without needing an Apple ID on the device | Configured inline with ACSC iOS hardening guidance, simplifies management and improves user experience with device onboarding. 
 Public App Store access | Disabled | Configured inline with ACSC iOS hardening guidance. Applications are installed under the VPP.
 Device Features | Configured | Device features configured in line with ACSC hardening guidance. 
 

--- a/blueprint/essential-eight-maturity.md
+++ b/blueprint/essential-eight-maturity.md
@@ -166,7 +166,7 @@ Windows 10 operating system updates are automatically deployed and installed on 
 
 Microsoft Defender for Endpoint provides an automated [vulnerability management capability](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/next-gen-threat-and-vuln-mgt?view=o365-worldwide). Operating system vulnerabilities, such as missing patches, are reported to the Microsoft 365 Defender portal and email alerts can be configured to notify cyber security personnel of newly detected vulnerabilities.
 
-The Windows 10 blueprint SOE is built using the 21H1 Semi-Annual Channel (SAC) release of Windows 10, which at the time of writing is the latest version assessed by the ACSC.
+The Windows 10 blueprint SOE is built using the 21H1 Semi-Annual Channel (SAC) release of Windows 10.
 
 The blueprint does not include any unsupported or legacy operating systems.
 

--- a/blueprint/essential-eight-maturity.md
+++ b/blueprint/essential-eight-maturity.md
@@ -64,12 +64,7 @@ Maturity level: 3
 
 Microsoft (first party) application updates are automatically deployed and installed on blueprint devices via MEM. This includes the Edge internet browser and Microsoft Office productivity suite. By default, the blueprint does not include any third-party applications. If required, MEM can also be used to deploy third-party application packages, including manually packaged patches.
 
-Microsoft Defender for Endpoint provides an [automated vulnerability management capability](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/next-gen-threat-and-vuln-mgt?view=o365-worldwide). Application vulnerabilities, such as missing patches, are reported to the Microsoft 365 Defender portal and email alerts can be configured to notify cyber security personnel of newly detected vulnerabilities. Note, Microsoft Defender for Endpoint requires one of the following [licenses](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/minimum-requirements):
-
-* Windows 10 Enterprise E5
-* Microsoft 365 E5 (M365 E5)
-* Microsoft 365 E5 Security
-* Microsoft Defender for Endpoint
+Microsoft Defender for Endpoint provides an [automated vulnerability management capability](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/next-gen-threat-and-vuln-mgt?view=o365-worldwide). Application vulnerabilities, such as missing patches, are reported to the Microsoft 365 Defender portal and email alerts can be configured to notify cyber security personnel of newly detected vulnerabilities.
 
 The blueprint does not include any unsupported or legacy applications.
 
@@ -169,14 +164,9 @@ Maturity level: 3
 
 Windows 10 operating system updates are automatically deployed and installed on blueprint devices using Windows Update for Business which is configured via MEM. For hybrid deployments, patches may be deployed to blueprint devices via Microsoft Endpoint Configuration Manager (MECM) or Windows Server Update Services (WSUS) rather than downloaded from the internet directly.
 
-Microsoft Defender for Endpoint provides an automated [vulnerability management capability](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/next-gen-threat-and-vuln-mgt?view=o365-worldwide). Operating system vulnerabilities, such as missing patches, are reported to the Microsoft 365 Defender portal and email alerts can be configured to notify cyber security personnel of newly detected vulnerabilities. Note, Microsoft Defender for Endpoint requires one of the following [licenses](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/minimum-requirements):
+Microsoft Defender for Endpoint provides an automated [vulnerability management capability](https://docs.microsoft.com/en-au/microsoft-365/security/defender-endpoint/next-gen-threat-and-vuln-mgt?view=o365-worldwide). Operating system vulnerabilities, such as missing patches, are reported to the Microsoft 365 Defender portal and email alerts can be configured to notify cyber security personnel of newly detected vulnerabilities.
 
-* Windows 10 Enterprise E5
-* Microsoft 365 E5 (M365 E5)
-* Microsoft 365 E5 Security
-* Microsoft Defender for Endpoint
-
-The Windows 10 blueprint SOE is built using the 21H1 Semi-Annual Channel (SAC) release of Windows 10, which at the time of writing is the [latest version](https://docs.microsoft.com/en-au/windows/release-health/release-information).
+The Windows 10 blueprint SOE is built using the 21H1 Semi-Annual Channel (SAC) release of Windows 10, which at the time of writing is the latest version assessed by the ACSC.
 
 The blueprint does not include any unsupported or legacy operating systems.
 

--- a/blueprint/office-365.md
+++ b/blueprint/office-365.md
@@ -45,32 +45,32 @@ Decision Point | Design Decision | Justification
 --- | --- | ---
 Office 365 Region | Australia | Aligns with ACSC guidance of utilising cloud services located in Australia.
 
-### License
+### Licence
 
-Microsoft licenses access to Office 365 and its security offerings through user-based licensing.
+Microsoft licences access to Office 365 and its security offerings through user-based licensing.
 
 Microsoft offers several enterprise licencing options for Office 365, Enterprise Mobility and Security (EMS), and Windows.
 
 These licencing options are summarised below:
 
-* Microsoft 365 E5 (recommended for this blueprint) – Top level Enterprise Plan. Microsoft 365 E5 includes everything inside Microsoft 365 E3 plus additional features and services (largely security and compliance related). In the case of Office 365 E5, the capabilities in Microsoft Defender for Office 365 suite as well as other services such as Office 365 Advanced Compliance are increased.
-* Microsoft 365 E3 - Mid range Enterprise Plan. Microsoft 365 E3 provides access to core products with enhanced features and security features. In the case of Office 365 E3, the Office client suite is included, and the service limits are increased.
+* Microsoft 365 E5 (recommended for this blueprint). Microsoft 365 E5 includes everything inside Microsoft 365 E3 plus additional features and services (largely security and compliance related). In the case of Office 365 E5, the capabilities in Microsoft Defender for Office 365 suite as well as other services such as Office 365 Advanced Compliance are increased.
+* Microsoft 365 E3. Microsoft 365 E3 provides access to core products with enhanced features and security features. In the case of Office 365 E3, the Office client suite is included, and the service limits are increased.
 
-To grant access to the services a license is assigned to an individual user account. A license can be assigned by an administrator at the time of the user account is created or through Azure AD group-based licensing. Azure AD group-based licensing allows an Administrator to associate a license to a group. Any members within the group will be assigned that license automatically. When a user is removed from the group the license is removed.
+To grant access to the services a licence is assigned to an individual user account. A licence can be assigned by an administrator at the time of the user account is created or through Azure AD group-based licensing. Azure AD group-based licensing allows an Administrator to associate a licence to a group. Any members within the group will be assigned that licence automatically. When a user is removed from the group the licence is removed.
 
 Licensing Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-Products Licensed | Microsoft 365 E5 | Microsoft 365 E5 licences combines Office 365 E5, EMS E5, and Windows 10 E5 are required to ensure that Office 365 tenant can be rated up to Protected. 
-License Allocation Method | Automated | Dynamic Security Groups in Azure AD will be used to automatically assign licences and reduce the management overhead associated with licensing.
+Products Licenced | Microsoft 365 E5 | Microsoft 365 E5 licences combines Office 365 E5, EMS E5, and Windows 10 E5 are required to ensure that Office 365 tenant can be rated up to Protected. 
+Licence Allocation Method | Automated | Dynamic Security Groups in Azure AD will be used to automatically assign licences and reduce the management overhead associated with licensing. 
 
 Licensing Configuration for all agencies and implementation types.
 
 Configuration | Value | Description
 --- | --- | ---
-Admin License Group | `rol-AgencyName-Administrator` | This is the group that the Agency administrators belong to.
-User License Groups | `rol-AgencyName-Users` | This is the group that the Agency non-administrator users belong to.
+Admin Licence Group | `rol-AgencyName-Administrator` | This is the group that the Agency administrators belong to.
+User Licence Groups | `rol-AgencyName-Users` | This is the group that the Agency non-administrator users belong to.
 
 ### Self service purchase
 
@@ -154,8 +154,6 @@ Role Based Access Control (RBAC) defines what a user or administrator has access
 
 Privileged Identity Management (PIM) can be leveraged to enhance the RBAC model for Azure Active Directory role-based management access, and parts of other Microsoft services like Office 365 and Microsoft Endpoint Manager. PIM requests are made through the Azure portal for elevated access only when they are required, and access is expired after a specified period.
 
-PIM requires an Azure AD Premium P2 license which is included with Microsoft 365 E5 licensing or E5 Security Step-up licensing.
-
 The following Office 365 roles can be assigned via PIM:
 
 * Exchange administrator.
@@ -189,8 +187,6 @@ Office 365 administrative sub-roles | Not Configured | Office 365 administrative
 Customer lockbox provides a time-boxed, secure mechanism for Microsoft Support Engineers to assist in customers support query in Office 365. Microsoft Support engineers will have to request authorisation from the Agency to access the underlying data in Office 365 tenant.
 
 Customer Lockbox address situations where Microsoft Engineers require access to client data within Office 365 to resolve an incident. All access requests are recorded for auditing purpose.
-
-Customer Lockbox requires Microsoft 365 E5 licensing or E5 Compliance licensing.
 
 Customer Lockbox Design Decisions for all agencies and implementation types.
 
@@ -556,7 +552,7 @@ Decision Point | Design Decision | Justification
 --- | --- | ---
 Disable IMAP | Configured | IMAP will be disabled to meet ACSC guidance to disable unneeded features.
 Disable POP | Configured | POP will be disabled to meet ACSC guidance to disable unneeded features.
-Exchange Mailbox Size | 100GB per user | Included with Office 365 E3 / E5 licencing.
+Exchange Mailbox Size | 100GB per user | Maximum mailbox size available. 
 Language | English | The default language is English, users will have the ability to adjust this if required.
 Default time zone | GMT +10 | The default time zone is GMT +10 however this will be adjusted based on user location.
 Exchange Message Size Limits | Up to 90MB | Default setting. Note that message limits may be smaller when sending messages to external mail recipients (can be as low as 10MB).
@@ -1267,7 +1263,7 @@ Classification labels are published to users using Label Policies. Label Policie
 
 * Manually - The label is applied manually by the end-user.
 * Automatically applied based on the location of the document - Labels can be configured to automatically apply based on the location of the document. For example, SharePoint.
-* Automatically applied based on detected Sensitive Information Type - Labels can be configured to automatically apply based on the type of sensitive information found. For example, documents containing Australian drivers license numbers.
+* Automatically applied based on detected Sensitive Information Type - Labels can be configured to automatically apply based on the type of sensitive information found. For example, documents containing Australian drivers licence numbers.
 
 At the time of writing, sensitivity labels cannot be configured to satisfy all of the requirements listed in the Protective Security Policy Framework (PSPF). Some of these limitations are:
 
@@ -1377,7 +1373,7 @@ A DLP policy can be configured to:
 
 At the time of writing Office 365 has over 200 prebuilt sensitive information types (Australian Passport Numbers etc.). In addition to the prebuilt sensitive information types custom types can be created. These custom types look for strings, patterns, or key words.
 
-Note, endpoint DLP requires onboarding of those devices into Microsoft Defender for Endpoint and requires an E5 license. Agencies should consider the use of Endpoint DLP as part of a unified DLP strategy.
+Note, endpoint DLP requires onboarding of those devices into Microsoft Defender for Endpoint. Agencies should consider the use of Endpoint DLP as part of a unified DLP strategy.
 
 Data Loss Prevention Design Decisions for all agencies and implementation types.
 
@@ -1623,7 +1619,7 @@ Do not let users click through safe links to original URL  | Checked | If end-us
 
 The Safe Attachments feature checks email attachments after the email is received but before it is delivered to the user mailbox.
 
-When an Safe Attachments policy is in place and an end-user who is covered by that policy views their email in Office 365, their email attachments are checked, and appropriate actions are taken, based on the configured policies. To deploy this feature, an Office 365 E5 subscription or an Advanced Threat Protection licence is required.
+When an Safe Attachments policy is in place and an end-user who is covered by that policy views their email in Office 365, their email attachments are checked, and appropriate actions are taken, based on the configured policies.
 
 Safe Attachments Design Decisions for all agencies and implementation types.
 

--- a/blueprint/overview.md
+++ b/blueprint/overview.md
@@ -66,6 +66,21 @@ Blueprint artefacts provide guidance on integration between MECM and Intune for 
 
 The blueprint is based on a principle of 'engineered to Protected' to enhance the cyber security postures of adopting agencies. It is suitable for agencies aiming for Protected and below.
 
+The blueprint design and configuration at Protected assumes the agency has available the licencing level of Microsoft 365 E5, or the equivalent Microsoft 365 E3 with Microsoft 365 E5 security and compliance add-ons.
+
+The VSA 4 Common Cloud Commitment consists of:
+
+* Windows 10 E3.
+* Office 365 E3.
+* Enterprise Mobility and Security E3.
+* Productivity server licences (Exchange Server, SharePoint Server, Lync/Skype Server).
+* Office Device licences.
+
+At a minimum, Microsoft recommends the following licensing in addition to the VSA 4 Common Cloud Commitment to satisfy Protected level requirements:
+
+* Microsoft 365 E5 Security.
+* Microsoft 365 E5 Compliance.
+
 Agencies that implement the blueprint at a Protected level will need to configure some components differently to enable connectivity to supporting systems. 
 
 Components that transfer Protected information outside of an agency's environment include:

--- a/blueprint/platform.md
+++ b/blueprint/platform.md
@@ -823,8 +823,6 @@ Examples of the Conditional Access App Control policies that can be configured t
 * Block access – based on specific risk factors can prevent users and/or devices from accessing specific resources across one or all connected apps.
 * Block custom activities – application-specific events can be blocked if they increase the risk of data leakage or exfiltration.
 
-Note, to use Conditional Access App Control an Azure AD Premium P1 license is required in addition to the Defender for Cloud Apps license.
-
 Conditional Access App Control Protection Design Decisions for all agencies and implementation types.
 
 Decision Point | Design Decision | Justification
@@ -926,7 +924,7 @@ SIEM agents Design Decisions for cloud native implementations.
 Decision Point | Design Decision | Justification
 --- | --- | ---
 Microsoft Sentinel integration | Configured | To support integration between Defender for Cloud Apps and Microsoft cloud native SIEM solution.
-Microsoft Sentinel license | Yes | To enable Microsoft Sentinel integration an Microsoft Sentinel license is required.
+Microsoft Sentinel license | Yes | To enable Microsoft Sentinel integration a Microsoft Sentinel license is required. 
 
 SIEM agents Design Decisions for hybrid implementations.
 
@@ -989,7 +987,6 @@ Defender for Identity Design Decisions for hybrid implementations
 
 Decision Point | Design Decision | Justification
 --- | --- | ---
-License | Enterprise Mobility + Security 5 (EMS E5) | An Enterprise Mobility + Security 5 (EMS E5) license is required for Defender for Identity.
 Number of Defender for Identity instances | One | A single Defender for Identity instance can monitor multiple AD DS forests.
 Defender for Identity instance name | {agency-instance-name}.atp.azure.com | The Defender for Identity cloud service will be given an Defender for Identity instance name which will be used to access the Defender for Identity portal.
 Forests and domains to be monitored by Defender for Identity | {agency}.gov.au | Nominated agency forests and domains.
@@ -1178,7 +1175,6 @@ Office 365 and other enterprise SaaS applications that use Azure AD as their ide
 
 Azure AD tenant restrictions prerequisites are as follows:
 
-* A minimum of M365 E3 licensing (Azure AD Premium 1).
 * The agency's web filtering service supports TLS interception, HTTP header insertion, URL and FQDN filtering.
 * Endpoints must trust the web filtering services PKI certificate chain for TLS communications.  
 


### PR DESCRIPTION
Changes include
- Include statement that this design is based on E5 or E3 with security add-ons
- move VSA 4 statement to overview
- only inlcude gerneral licence requirement , not individual products