### PR TITLE
Enable fraud alerts, notifications, number matching and additional context for MFA

### DIFF
--- a/blueprint/essential-eight-maturity.md
+++ b/blueprint/essential-eight-maturity.md
@@ -199,6 +199,8 @@ As the blueprint's implementation of MFA is not considered verifier impersonatio
 
 It is recommended agencies review Azure AD sign-in logs and MCAS alerts to detect potentially malicious authentication attempts.
 
+Agencies utilising Microsoft Authenticator should configure [Azure AD Multi-Factor Authentication settings](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-mfasettings) to enable fraud alerts and notifications to allow users to report fraudulent MFA verification requests.
+
 Agencies seeking to reach maturity level 3 should consider alternative authentication methods not currently included in the blueprint.
 
 ## Regular backups

--- a/blueprint/essential-eight-maturity.md
+++ b/blueprint/essential-eight-maturity.md
@@ -199,7 +199,7 @@ As the blueprint's implementation of MFA is not considered verifier impersonatio
 
 It is recommended agencies review Azure AD sign-in logs and MCAS alerts to detect potentially malicious authentication attempts.
 
-Agencies utilising Microsoft Authenticator should configure [Azure AD Multi-Factor Authentication settings](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-mfasettings) to enable fraud alerts and notifications to allow users to report fraudulent MFA verification requests.
+Agencies utilising Microsoft Authenticator should configure [Azure AD Multi-Factor Authentication settings](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-mfasettings) to enable fraud alerts and notifications to allow users to report fraudulent MFA verification requests. Enabling [number matching](https://learn.microsoft.com/en-us/azure/active-directory/authentication/how-to-mfa-number-match), [additional context](https://learn.microsoft.com/en-us/azure/active-directory/authentication/how-to-mfa-additional-context) (geographic location and app of sign-in) can also be leveraged to strengthen notification-based MFA and mitigate against adversary-in-the-middle phishing.
 
 Agencies seeking to reach maturity level 3 should consider alternative authentication methods not currently included in the blueprint.
 


### PR DESCRIPTION
Enable fraud alerts and notifications for Microsoft Authenticator. "MFA fatigue attacks" have seen an increase in popularity recently. Some high profile breaches have been the result of them. The default configuration of an Azure AD tenant is such that an attacker who has phished a user's credentials can make an unlimited number of MFA push requests until the victim simply gives in. Even stopping short of an MFA fatigue attack, it may not occur to a user that an unsolicited prompt is indicative of their password being compromised.