### PR TITLE
Tweak to remove config bundle path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ exclude:
   - LICENSE.md
   - assets/sass
   - vendor
+  - bundle
   - Staticfile
   - .jekyll-cache
   - .git


### PR DESCRIPTION
Attempted workaround for netlify build issues on https://answers.netlify.com/t/build-fails-could-not-find-bundler/86045/11